### PR TITLE
Ignore non loaded associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ by adding `ecto_morph` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:ecto_morph, "~> 0.1.13"}
+    {:ecto_morph, "~> 0.1.14"}
   ]
 end
 ```

--- a/lib/ecto_morph.ex
+++ b/lib/ecto_morph.ex
@@ -201,6 +201,8 @@ defmodule EctoMorph do
   end
 
   def generate_changeset(data, current = %{__struct__: schema}, fields) do
+    data = filter_not_loaded_relations(data)
+
     embedded_field_whitelist =
       Enum.filter(fields, fn
         {field, _} -> field in schema_embeds(schema)
@@ -265,6 +267,15 @@ defmodule EctoMorph do
 
   def generate_changeset(data, schema, fields) do
     generate_changeset(data, struct(schema, %{}), fields)
+  end
+
+  defp filter_not_loaded_relations(map = %{}) do
+    map
+    |> Enum.filter(fn
+      {_, %Ecto.Association.NotLoaded{}} -> false
+      _ -> true
+    end)
+    |> Enum.into(%{})
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -7,9 +7,9 @@ defmodule EctoMorph.MixProject do
       app: :ecto_morph,
       licenses: "",
       description: description(),
-      version: "0.1.13",
+      version: "0.1.14",
       package: package(),
-      elixir: "~> 1.8",
+      elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       source_url: "https://github.com/Adzz/Zip",
       deps: deps()


### PR DESCRIPTION
Incoming changes can be a struct. Sometimes they may have unloaded relations in them which can cause us problems. We should instead ignore them as there clearly aren't any changes to be had there.