### PR TITLE
Allow specifying validation fns

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ by adding `ecto_morph` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:ecto_morph, "~> 0.1.15"}
+    {:ecto_morph, "~> 0.1.16"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -86,13 +86,41 @@ Often you'll want to do some validations, that's easy:
 |> Ecto.Changeset.validate_required([:thing])
 |> EctoMorph.into_struct()
 
-# or 
+# or
 
 %{"thing" => "foo", "embed" => %{"bar"=> "baz"}}
 |> EctoMorph.generate_changeset(Test, [:thing])
 |> Ecto.Changeset.validate_change(...)
 |> Repo.insert!
 ```
+
+### Valiating Nested Changesets
+
+Easily the coolest feature, say you have nested changesets via embeds or has_one/many, you can now specify a path to a changeset and specify a validation function for the changeset(s) at the end of that path. If your path ends at a list of changesets (because your model has a has_many relation for example), each of those changesets will be validated.
+
+```elixir
+%{"thing" => "foo", "embed" => %{"bar"=> "baz"}}
+|> EctoMorph.generate_changeset(Test)
+|> EctoMorph.validate_nested_changeset([:embed], &MyEmbed.validate/1)
+
+# or
+json = %{
+  "has_many" => [
+    %{"steamed_hams" => [%{"pickles" => 1}, %{"pickles" => 2}]},
+    %{"steamed_hams" => [%{"pickles" => 1}]},
+    %{"steamed_hams" => [%{"pickles" => 4}, %{"pickles" => 5}]}
+  ]
+}
+
+# Here each of the steamed_hams above will have their pickle count validated:
+
+EctoMorph.generate_changeset(json, MySchema)
+|> EctoMorph.validate_nested_changeset([:has_many, :steamed_hams], fn changeset ->
+  changeset
+  |> Ecto.Changeset.validate_number(:pickles, greater_than: 3)
+end)
+```
+
 
 Other abilities include creating a map from an ecto struct, dropping optional fields if you decide to:
 

--- a/lib/ecto_morph.ex
+++ b/lib/ecto_morph.ex
@@ -340,6 +340,21 @@ defmodule EctoMorph do
     |> Map.drop(fields_to_drop)
   end
 
+  defmodule InvalidPathError do
+    @moduledoc """
+    validate_nested_changeset requires a path in which each location points to a nested changeset.
+    If we are not given that, we raise an error.
+    """
+    defexception message:
+                   "EctoMorph.validate_nested_changeset/3 requires that each field " <>
+                     "in the path_to_nested_changeset points to a nested changeset."
+  end
+
+  defmodule InvalidValidationFunction do
+    defexception message:
+                   "Validation functions are expected to take a changeset and to return one"
+  end
+
   @doc """
   Allows us to specify validations for nested changesets. Accepts a path to a nested changeset,
   and a validation function. The validation fun will be passed the changeset at the end of the
@@ -349,35 +364,63 @@ defmodule EctoMorph do
   changeset between the root changeset and the nested one), but the error messages will remain
   on the changeset they are relevant for. This is in line with how Ecto works elsewhere like
   in cast_embed etc. To get the nested error messages you can use `Ecto.Changeset.traverse_errors`
+
+  ### Examples
+
+  ```elixir
+  EctoMorph.generate_changeset(%{nested: %{foo: 3}})
+  |> EctoMorph.validate_nested_changeset([:nested], fn changeset ->
+    Ecto.Changeset.validate_number(changeset, :foo, greater_than: 5)
+  end)
+
+  changeset = EctoMorph.generate_changeset(%{nested: %{double_nested: %{field: 6}}})
+  EctoMorph.validate_nested_changeset(changeset, [:nested, :double_nested], &MySchema.validate/1)
+  ```
   """
-  def validate_nested_changeset(changeset, path_to_schema = [field | _], validation_fun) do
-    walk_the_path(changeset, {[], path_to_schema}, validation_fun)
+  def validate_nested_changeset(_, [], _) do
+    raise InvalidPathError, "You must provide at least one field in the path"
+  end
+
+  def validate_nested_changeset(changeset, path_to_nested_changeset, validation_fun) do
+    walk_the_path(changeset, {[], path_to_nested_changeset}, validation_fun)
   end
 
   # We are at the end if the remaining_path is empty.
   def walk_the_path(changeset, {[{field, child}], []}, validation_fun) do
     # Again raise a better error but the validation fun should accept and return a changeset.
     # (and ideally not do any side effects)
-    validated = %Ecto.Changeset{} = validation_fun.(child)
-    new_changes = %{ changeset.changes | field => validated}
-    retreat(%{changeset | changes: new_changes, valid?: validated.valid? }, [])
+    with validated = %Ecto.Changeset{} <- validation_fun.(child) do
+      new_changes = %{changeset.changes | field => validated}
+      retreat(%{changeset | changes: new_changes, valid?: validated.valid?}, [])
+    else
+      _ -> raise InvalidValidationFunction
+    end
   end
 
   def walk_the_path(changeset, {[{field, child} | rest = [{_, parent} | _]], []}, validation_fun) do
-    validated = %Ecto.Changeset{} = validation_fun.(child)
-    new_changes = %{ changeset.changes | field => validated}
-    retreat(%{parent | changes: new_changes, valid?: validated.valid?}, rest)
+    with validated = %Ecto.Changeset{} <- validation_fun.(child) do
+      new_changes = %{changeset.changes | field => validated}
+      retreat(%{parent | changes: new_changes, valid?: validated.valid?}, rest)
+    else
+      _ -> raise InvalidValidationFunction
+    end
   end
 
   def walk_the_path(changeset, {prev_changesets, [field | rest]}, validation_fun) do
-    # This should be a changeset, otherwise the path is wrong. We can enforce that with a better error
-    nested_changeset = %Ecto.Changeset{} = Map.fetch!(changeset.changes, field)
-    # We have to put the whole changeset in not the field
-    walk_the_path(
-      changeset,
-      {[{field, nested_changeset} | prev_changesets], rest},
-      validation_fun
-    )
+    with nested_changeset = %Ecto.Changeset{} <- Map.get(changeset.changes, field) do
+      walk_the_path(
+        changeset,
+        {[{field, nested_changeset} | prev_changesets], rest},
+        validation_fun
+      )
+    else
+      _ ->
+        raise InvalidPathError, """
+        EctoMorph.validate_nested_changeset/3 requires that each field in the path_to_nested_changeset
+        points to a nested changeset. It looks like :#{field} points to a change that isn't a nested
+        changeset, or doesn't exist at all.
+        """
+    end
   end
 
   def retreat(changeset, []) do
@@ -389,7 +432,7 @@ defmodule EctoMorph do
   end
 
   def retreat(changeset, [{field, _} | rest = [{_, parent} | _]]) do
-    new_changes = %{ parent.changes | field => changeset}
+    new_changes = %{parent.changes | field => changeset}
     retreat(%{parent | changes: new_changes, valid?: changeset.valid?}, rest)
   end
 

--- a/lib/ecto_morph.ex
+++ b/lib/ecto_morph.ex
@@ -380,6 +380,8 @@ defmodule EctoMorph do
   EctoMorph.validate_nested_changeset(changeset, [:nested, :double_nested], &MySchema.validate/1)
   ```
   """
+  # Now the natural question is can we extend this to allow the Repo.preload syntax ? I.e. a tree?
+  # [:this, plus: :this, and: [:also, these: :too]] ? I think the zipper Idea helps that along a lot.
   def validate_nested_changeset(_, [], _) do
     raise InvalidPathError, "You must provide at least one field in the path"
   end

--- a/lib/ecto_morph.ex
+++ b/lib/ecto_morph.ex
@@ -340,6 +340,30 @@ defmodule EctoMorph do
     |> Map.drop(fields_to_drop)
   end
 
+  # def validate_relation(changeset, path_to_relation, validation_fun) do
+
+  #   # update in wont work as changesets dont implement it. So what we have to do is manually
+  #   # recurse. DFS. But that's inefficient. So like it'd be better to get all of the config
+  #   # up front then reduce over the thing once.
+
+  #   with {:relation, changeset = %Ecto.Changeset{}} <-
+  #          {:relation, get_in(changeset.changes, path_to_relation)} do
+  #     update_in(changeset |> Map.from_struct(), [:changes | path_to_relation], fn _ ->
+  #       validation_fun.(changeset)
+  #     end)
+  #     |> IO.inspect(limit: :infinity, label: "")
+  #   else
+  #     {:relation, nil} ->
+  #       {:error,
+  #        "No changes for that relation found. Ensure the relation exists and that there are changes for it in this changeset."}
+  #   end
+
+  #   #   nil ->
+  #   #     {:error,
+  #   #      "No changes for that relation found. Ensure the relation exists and that there are changes for it in this changeset."}
+  #   # end
+  # end
+
   defp cast_embeds(changeset, relations) do
     Enum.reduce(relations, changeset, fn
       {relation, fields}, changeset ->

--- a/lib/ecto_morph.ex
+++ b/lib/ecto_morph.ex
@@ -427,9 +427,9 @@ defmodule EctoMorph do
 
         {valid?, changes} =
           Enum.reduce(changesets, {true, []}, fn nested_changeset, {valid, acc} ->
+            # validate_nested_changeset(nested_changeset, rest, validation_fun)
             result =
-              validate_nested_changeset(nested_changeset, rest, validation_fun)
-              # walk_the_path({[{field, nested_changeset} | prev_changesets], rest}, validation_fun)
+              walk_the_path({[{field, nested_changeset} | prev_changesets], rest}, validation_fun)
               |> IO.inspect(limit: :infinity, label: "")
 
             {valid && result.valid?, [result | acc]}

--- a/lib/ecto_morph.ex
+++ b/lib/ecto_morph.ex
@@ -388,6 +388,16 @@ defmodule EctoMorph do
     walk_the_path({[{nil, changeset}], path_to_nested_changeset}, validation_fun)
   end
 
+  def walk_the_path({[{field, parent = %Ecto.Changeset{}}], []}, validation_fun) do
+    with validated = %Ecto.Changeset{} <- validation_fun.(parent) do
+      # new_changes = %{parent.changes | field => validated}
+      # retreat(%{parent | changes: new_changes, valid?: validated.valid?}, [])
+      validated
+    else
+      _ -> raise InvalidValidationFunction
+    end
+  end
+
   def walk_the_path({[{field, child}, {_, parent = %Ecto.Changeset{}}], []}, validation_fun) do
     "First" |> IO.inspect(limit: :infinity, label: "")
 
@@ -429,8 +439,8 @@ defmodule EctoMorph do
           Enum.reduce(changesets, {true, []}, fn nested_changeset, {valid, acc} ->
             # validate_nested_changeset(nested_changeset, rest, validation_fun)
             result =
-              walk_the_path({[{field, nested_changeset} | prev_changesets], rest}, validation_fun)
-              |> IO.inspect(limit: :infinity, label: "")
+              walk_the_path({[{field, nested_changeset}], rest}, validation_fun)
+              |> IO.inspect(limit: :infinity, label: "RESULT")
 
             {valid && result.valid?, [result | acc]}
           end)

--- a/lib/ecto_morph.ex
+++ b/lib/ecto_morph.ex
@@ -388,7 +388,7 @@ defmodule EctoMorph do
     walk_the_path({[{nil, changeset}], path_to_nested_changeset}, validation_fun)
   end
 
-  def walk_the_path({[{field, parent = %Ecto.Changeset{}}], []}, validation_fun) do
+  def walk_the_path({[{_, parent = %Ecto.Changeset{}}], []}, validation_fun) do
     with validated = %Ecto.Changeset{} <- validation_fun.(parent) do
       validated
     else

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule EctoMorph.MixProject do
       app: :ecto_morph,
       licenses: "",
       description: description(),
-      version: "0.1.15",
+      version: "0.1.16",
       package: package(),
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,

--- a/test/ecto_morph_test.exs
+++ b/test/ecto_morph_test.exs
@@ -1062,12 +1062,24 @@ defmodule EctoMorphTest do
   end
 
   describe "Specifying validation funs" do
-    test "When it is valid, it's all good", %{json: json} do
+    test "Has one, 1 level nested", %{json: json} do
+      # PASS
       result =
         EctoMorph.generate_changeset(json, SchemaUnderTest)
         |> EctoMorph.validate_nested_changeset([:aurora_borealis], fn changeset ->
           changeset
           |> Ecto.Changeset.validate_number(:probability, less_than: 5)
+        end)
+
+      assert result.valid? == true
+      assert result.changes.aurora_borealis.errors == []
+
+      # FAIL
+      result =
+        EctoMorph.generate_changeset(json, SchemaUnderTest)
+        |> EctoMorph.validate_nested_changeset([:aurora_borealis], fn changeset ->
+          changeset
+          |> Ecto.Changeset.validate_number(:probability, greater_than: 5)
         end)
 
       assert result.valid? == true

--- a/test/ecto_morph_test.exs
+++ b/test/ecto_morph_test.exs
@@ -1117,7 +1117,7 @@ defmodule EctoMorphTest do
         EctoMorph.generate_changeset(json, SchemaUnderTest)
         |> EctoMorph.validate_nested_changeset([:steamed_hams], fn changeset ->
           changeset
-          |> Ecto.Changeset.validate_number(:pickles, greater_than: 5)
+          |> Ecto.Changeset.validate_number(:pickles, greater_than: 55)
         end)
 
       assert result.valid? == false
@@ -1137,12 +1137,11 @@ defmodule EctoMorphTest do
     end
 
     test "has_many nested " do
-      # Pass validation
       json = %{
         steamed_hams: [
           %{double_nested_schema: %{value: "Hi"}},
           %{double_nested_schema: %{value: "Hi there"}},
-          %{double_nested_schema: %{value: "Passing validation is easy"}},
+          %{double_nested_schema: %{value: "Passing validation is easy"}}
         ]
       }
 
@@ -1153,6 +1152,21 @@ defmodule EctoMorphTest do
         end)
 
       assert result.valid? == false
+      [first, second, third] = result.changes.steamed_hams
+
+      assert first.changes.double_nested_schema.errors == [
+               {:value,
+                {"should be at least %{count} character(s)",
+                 [count: 15, validation: :length, kind: :min, type: :string]}}
+             ]
+
+      assert second.changes.double_nested_schema.errors == [
+               {:value,
+                {"should be at least %{count} character(s)",
+                 [count: 15, validation: :length, kind: :min, type: :string]}}
+             ]
+
+      assert third.changes.double_nested_schema.errors == []
     end
 
     test "when it's invalid" do

--- a/test/ecto_morph_test.exs
+++ b/test/ecto_morph_test.exs
@@ -1122,17 +1122,20 @@ defmodule EctoMorphTest do
 
       assert result.valid? == false
 
-      assert Enum.map(result.changes.steamed_hams, & &1.errors) == [
-               [
-                 {:pickles,
-                  {"must be greater than %{number}",
-                   [validation: :number, kind: :greater_than, number: 5]}}
-               ],
-               [
-                 {:pickles,
-                  {"must be greater than %{number}",
-                   [validation: :number, kind: :greater_than, number: 5]}}
-               ]
+      [first, second] = result.changes.steamed_hams
+      assert first.valid? == false
+      assert second.valid? == false
+
+      assert first.errors == [
+               {:pickles,
+                {"must be greater than %{number}",
+                 [validation: :number, kind: :greater_than, number: 55]}}
+             ]
+
+      assert second.errors == [
+               {:pickles,
+                {"must be greater than %{number}",
+                 [validation: :number, kind: :greater_than, number: 55]}}
              ]
     end
 

--- a/test/ecto_morph_test.exs
+++ b/test/ecto_morph_test.exs
@@ -150,6 +150,7 @@ defmodule EctoMorphTest do
 
     schema "other_table" do
       field(:hen_to_eat, :integer)
+      has_one(:steamed_ham, SteamedHams)
     end
   end
 
@@ -1095,9 +1096,12 @@ defmodule EctoMorphTest do
     test "has one that has one - multi nested schemas" do
       # PASS validation
       result =
-        %{steamed_ham: %{double_nested_schema: %{value: "This is a string"}}}
-        |> EctoMorph.generate_changeset(SchemaUnderTest)
-        |> EctoMorph.validate_nested_changeset([:steamed_ham, :double_nested_schema], & &1)
+        %{has_one: %{steamed_ham: %{double_nested_schema: %{value: "This is a string"}}}}
+        |> EctoMorph.generate_changeset(TableBackedSchema)
+        |> EctoMorph.validate_nested_changeset(
+          [:has_one, :steamed_ham, :double_nested_schema],
+          & &1
+        )
 
       assert result.valid?
 

--- a/test/ecto_morph_test.exs
+++ b/test/ecto_morph_test.exs
@@ -1109,8 +1109,6 @@ defmodule EctoMorphTest do
           |> Ecto.Changeset.validate_number(:pickles, less_than: 5)
         end)
 
-      # What if some of the has_many don't have the nested data in it? Not invalid, but we also haven't
-      # validated it....
       assert result.valid? == true
       assert Enum.map(result.changes.steamed_hams, & &1.errors) == [[], []]
 
@@ -1138,8 +1136,23 @@ defmodule EctoMorphTest do
              ]
     end
 
-    test "has_many fails" do
-      # always embeds / embeds_many has_one / has_many...
+    test "has_many nested " do
+      # Pass validation
+      json = %{
+        steamed_hams: [
+          %{double_nested_schema: %{value: "Hi"}},
+          %{double_nested_schema: %{value: "Hi there"}},
+          %{double_nested_schema: %{value: "Passing validation is easy"}},
+        ]
+      }
+
+      result =
+        EctoMorph.generate_changeset(json, SchemaUnderTest)
+        |> EctoMorph.validate_nested_changeset([:steamed_hams, :double_nested_schema], fn ch ->
+          Ecto.Changeset.validate_length(ch, :value, min: 15)
+        end)
+
+      assert result.valid? == false
     end
 
     test "when it's invalid" do


### PR DESCRIPTION
This would allow us to validate nested changesets. The proposed solution is to have a `validate_nested_changeset` function which takes a path to the changeset you wish to validate, and a validation function. The idea is you could pipe them together as you wish:

```elixir
changeset
|> EctoMorph.validate_nested_changeset([:nested, :changset, :path], &MySchema.validate/1)
|> EctoMorph.validate_nested_changeset([:nested], &MyOtherSchema.validate/1)
|> EctoMorph.validate_nested_changeset([:some_other] &AnotherSchema.validate/1)
```

Need to finish support for has_many / embeds_many and test it, but the current proposal is that the validation function gets applied to each of the relations that may exist. Say you have Authors that have many posts, and you had this data:

```elixir
%{posts: [%{title: "6 Tricks Devs Hate"}, %{title: "Burger Recipe"}]}
|> EctoMorph.generate_changeset(Author)
|> EctoMorph.validate_nested_changeset([:posts], &Post.validate/1)
```
Each post would get validated. This get's even trickier though if posts have a nested relation, like tags....: The current proposal is that we'd validate every tag of every post provided in data:

```elixir
%{posts: [
  %{title: "6 Tricks Devs Hate", tags: [%{name: "clickbait"}, %{name: "marketing"}]}, 
  %{title: "Burger Recipe", tags: [%{name: "food"}, %{name: ""}]}]
}
|> EctoMorph.generate_changeset(Author)
|> EctoMorph.validate_nested_changeset([:posts], &Post.validate/1)
|> EctoMorph.validate_nested_changeset([:posts, :tags], &Tag.validate/1)
```

This does require however that all posts have tags, this would raise an error for example:

```elixir
%{posts: [
  %{title: "6 Tricks Devs Hate"}, 
  %{title: "Burger Recipe", tags: [%{name: "food"}, %{name: ""}]}]
}
|> EctoMorph.generate_changeset(Author)
|> EctoMorph.validate_nested_changeset([:posts], &Post.validate/1)
|> EctoMorph.validate_nested_changeset([:posts, :tags], &Tag.validate/1)
```

Essentially, each node in the path provided should point to a changeset in changes. If it doesn't we shout about it. And each validation function should take and return a changeset, if it doesn't we shout about it.

**UPDATE** has_many supported 🎉 

