### PR TITLE
Use ExDoc only in :docs env

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule EctoMorph.MixProject do
   defp deps do
     [
       {:ecto, ">= 3.0.3"},
-      {:ex_doc, "~> 0.19", only: :dev, runtime: false}
+      {:ex_doc, "~> 0.19", only: :docs, runtime: false}
     ]
   end
 


### PR DESCRIPTION
Since we have:

    defp elixirc_paths(:dev), do: ["lib", "test/support"]

The fixture modules are leaking to the docs: https://hexdocs.pm/ecto_morph/SteamedHams.html.

This means however that when releasing a new version you'd have to remember to do: `MIX_ENV=docs mix hex.publish`. Another small benefit is users cloning the repo to play with it won't need to compile ExDoc and its deps which by far take the most time in compiling this project :)