### PR TITLE
pass through options to recursive calls for deep filter by schema fields

### DIFF
--- a/lib/ecto_morph.ex
+++ b/lib/ecto_morph.ex
@@ -390,9 +390,9 @@ defmodule EctoMorph do
 
           if is_list(value) do
             # Has / embeds many
-            {key, Enum.map(value, &deep_filter_by_schema_fields(&1, relation_schema))}
+            {key, Enum.map(value, &deep_filter_by_schema_fields(&1, relation_schema, opts))}
           else
-            {key, deep_filter_by_schema_fields(value, relation_schema)}
+            {key, deep_filter_by_schema_fields(value, relation_schema, opts)}
           end
         else
           # Do we handle non ecto structs as the data being filtered...
@@ -401,10 +401,10 @@ defmodule EctoMorph do
               # This essentially tries to work for through relations if it's a struct by
               # getting the struct schema out of the struct.
               %{__struct__: relation_schema} = value ->
-                {key, deep_filter_by_schema_fields(value, relation_schema)}
+                {key, deep_filter_by_schema_fields(value, relation_schema, opts)}
 
               value when is_list(value) ->
-                {key, Enum.map(value, &deep_filter_by_schema_fields(&1, schema))}
+                {key, Enum.map(value, &deep_filter_by_schema_fields(&1, schema, opts))}
 
               value ->
                 {key, value}

--- a/test/deep_filter_by_schema_fields_test.exs
+++ b/test/deep_filter_by_schema_fields_test.exs
@@ -219,6 +219,24 @@ defmodule EctoMorph.DeepFilterBySchemaFieldsTest do
              } = result
     end
 
+    test "filtering nested not loaded" do
+      data = %NestedHasMany{
+        schema_under_test_id: "testid_123",
+        has_many: %HasMany{geese_to_feed: 5, through: %Through{}}
+      }
+
+      result =
+        EctoMorph.deep_filter_by_schema_fields(data, NestedHasMany, filter_not_loaded: true)
+
+      assert %{
+               schema_under_test_id: "testid_123",
+               has_many: %{
+                 geese_to_feed: 5,
+                 steamed_hams: nil
+               }
+             } = result
+    end
+
     test "when relations aren't loaded" do
       data = %OverlapAndSome{
         binary_id: 1,

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -120,6 +120,17 @@ defmodule HasMany do
   end
 end
 
+defmodule NestedHasMany do
+  use Ecto.Schema
+
+  schema "nested_has_many" do
+    field(:table_backed_schema_id, :string)
+    field(:schema_under_test_id, :string)
+
+    has_one(:has_many, HasMany)
+  end
+end
+
 defmodule HasOne do
   use Ecto.Schema
 


### PR DESCRIPTION
Noticed this when trying to generate a map for a schema with a relation which itself had a relation which wasn't loaded. Pass through the options to recursive calls so they are all treated the same.  